### PR TITLE
Fixed issue with Get-Alias error

### DIFF
--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -224,7 +224,7 @@ Function Start-RSJob {
                 }
 
                 #Check for an alias and add it as well
-                If ($Alias = Get-Alias -Definition $Function) {
+                If ($Alias = Get-Alias -Definition $Function -ErrorAction SilentlyContinue) {
                     $AliasEntry = New-Object System.Management.Automation.Runspaces.SessionStateAliasEntry -ArgumentList $Alias.Name,$Alias.Definition
                     $InitialSessionState.Commands.Add($AliasEntry)
                 }


### PR DESCRIPTION
Added SilentlyContinue to bypass the terminating error produced when the function being loaded doesn't have any aliases.
